### PR TITLE
Refresh Token과 user-agent를 묶어 복합키로 관리.

### DIFF
--- a/Server/app/doc/__init__.py
+++ b/Server/app/doc/__init__.py
@@ -16,6 +16,14 @@ JWT_ACCESS_TOKEN = {
     'required': 'true'
 }
 
+JWT_REFRESH_TOKEN = {
+    'name': 'Authorization',
+    'description': 'jwt refresh token',
+    'in': 'header',
+    'type': 'str',
+    'required': 'true'
+}
+
 SAMPLE_OBJECT_IDS = [
     '5acddc2bc2a93f68ce96f5c4',
     '5acddc2bc2a93f68ce96f5c9',

--- a/Server/app/doc/account/auth.py
+++ b/Server/app/doc/account/auth.py
@@ -1,4 +1,4 @@
-from app.doc import parameter
+from app.doc import parameter, JWT_REFRESH_TOKEN
 from app.doc.account import SAMPLE_ACCESS_TOKEN, SAMPLE_REFRESH_TOKEN
 
 AUTH_POST = {
@@ -20,6 +20,28 @@ AUTH_POST = {
         },
         '401': {
             'description': '로그인 실패'
+        }
+    }
+}
+
+REFRESH_POST = {
+    'tags': ['Account'],
+    'description': 'Token refreshing',
+    'parameters': [
+        JWT_REFRESH_TOKEN
+    ],
+    'responses': {
+        '200': {
+            'description': '재발급 성공',
+            'examples': {
+                '': {
+                    'accessToken': SAMPLE_ACCESS_TOKEN,
+                    'refreshToken': SAMPLE_REFRESH_TOKEN
+                }
+            }
+        },
+        '403': {
+            'description': '잘못 된 토큰. (Wrong Token)'
         }
     }
 }

--- a/Server/app/model/__init__.py
+++ b/Server/app/model/__init__.py
@@ -11,3 +11,4 @@ from .point.history import PointHistoryModel
 from .point.item import PointItemModel
 from .point.status import PointStatusModel
 from .report import FacilityReportModel
+from app.model.account.token import TokenModel

--- a/Server/app/model/account/student.py
+++ b/Server/app/model/account/student.py
@@ -11,11 +11,11 @@ from app.model.mixin import BaseMixin
 
 class StudentModel(db.Model, BaseMixin):
     __tablename__ = 'student'
-    id = db.Column(db.String, primary_key=True)
-    pw = db.Column(db.String)
-    name = db.Column(db.String)
-    number = db.Column(db.Integer)
-    email = db.Column(db.String)
+    id: str = db.Column(db.String, primary_key=True)
+    pw: str = db.Column(db.String)
+    name: str = db.Column(db.String)
+    number: int = db.Column(db.Integer)
+    email: str = db.Column(db.String)
 
     def __init__(self, id: str, pw: str, name: str, number: int, email: str):
         self.id = id

--- a/Server/app/model/account/token.py
+++ b/Server/app/model/account/token.py
@@ -6,6 +6,8 @@ from flask_jwt_extended import (
     decode_token,
     get_jwt_identity
 )
+
+from app.exception import ForbiddenException
 from app.extension import db
 from app.model.mixin import BaseMixin
 
@@ -32,6 +34,9 @@ class TokenModel(db.Model, BaseMixin):
             refresh_token=refresh_token,
             user_agent=user_agent
         ).first()
+
+        if not token:
+            raise ForbiddenException()
 
         return token
 

--- a/Server/app/model/account/token.py
+++ b/Server/app/model/account/token.py
@@ -1,0 +1,67 @@
+from time import time
+
+from flask_jwt_extended import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    get_jwt_identity
+)
+from app.extension import db
+from app.model.mixin import BaseMixin
+
+
+class TokenModel(db.Model, BaseMixin):
+    __tablename__ = 'token'
+    owner: str = db.Column(db.String, db.ForeignKey('student.id', ondelete='CASCADE'))
+    refresh_token: str = db.Column(db.String, primary_key=True)
+    user_agent: str = db.Column(db.String, primary_key=True)
+
+    def __init__(self, owner: str, refresh_token: str, user_agent: str):
+        self.owner: str = owner
+        self.refresh_token: str = refresh_token
+        self.user_agent: str = user_agent
+
+    @classmethod
+    def _verify_refresh_token(cls, refresh_token, user_agent):
+        token = TokenModel.query.filter_by(
+            owner=get_jwt_identity(),
+            refresh_token=refresh_token,
+            user_agent=user_agent
+        ).first()
+
+        return token
+
+    @classmethod
+    def create_new_token(cls, owner: str, user_agent: str) -> dict:
+        new_access_token = create_access_token(owner)
+        new_refresh_token = create_refresh_token(owner)
+
+        TokenModel(
+            owner=owner,
+            refresh_token=new_refresh_token,
+            user_agent=user_agent
+        ).save()
+
+        return {
+            'accessToken': new_access_token,
+            'refreshToken': new_refresh_token
+        }
+
+    @classmethod
+    def create_refresh_token(cls, refresh_token, user_agent):
+        new_token = {}
+        token = cls._verify_refresh_token(refresh_token, user_agent)
+        token_data = decode_token(refresh_token)
+
+        new_access_token = create_access_token(token_data.identity)
+        new_token['accessToken'] = new_access_token
+
+        # refresh token 의 유효 기간이 3일 미만일 경우 refresh_token 또한 재발급.
+        if (time() - token_data.get('exp')) < 259200:
+            new_refresh_token = create_refresh_token(token_data.identity)
+            token.refresh_token = new_refresh_token
+            new_token['refreshToken'] = new_refresh_token
+
+            db.session.commit()
+
+        return new_token

--- a/Server/app/model/account/token.py
+++ b/Server/app/model/account/token.py
@@ -22,6 +22,10 @@ class TokenModel(db.Model, BaseMixin):
         self.user_agent: str = user_agent
 
     @classmethod
+    def find_refresh_token(cls, owner: str, user_agent: str):
+        return TokenModel.query.filter_by(owner=owner, user_agent=user_agent).first()
+
+    @classmethod
     def _verify_refresh_token(cls, refresh_token, user_agent):
         token = TokenModel.query.filter_by(
             owner=get_jwt_identity(),
@@ -35,6 +39,10 @@ class TokenModel(db.Model, BaseMixin):
     def create_new_token(cls, owner: str, user_agent: str) -> dict:
         new_access_token = create_access_token(owner)
         new_refresh_token = create_refresh_token(owner)
+
+        exist_token = cls.find_refresh_token(owner, user_agent)
+        if exist_token:
+            exist_token.delete()
 
         TokenModel(
             owner=owner,

--- a/Server/app/model/apply/goingout.py
+++ b/Server/app/model/apply/goingout.py
@@ -41,7 +41,7 @@ class GoingOutApplyModel(db.Model, BaseMixin):
     return_date: datetime = db.Column(db.DateTime)
     reason: str = db.Column(db.String)
     # 0: 외출 전. 1: 외출 중, 2: 복귀 완료
-    going_out_status: int = db.Column(db.Integer, default=0)
+    goingout_status: int = db.Column(db.Integer, default=0)
 
     def __init__(self, student_id: str, go_out_date: datetime, return_date: datetime, reason: str):
         self.student_id = student_id

--- a/Server/app/view/account/__init__.py
+++ b/Server/app/view/account/__init__.py
@@ -7,9 +7,10 @@ account_api = Api(account_blueprint)
 info_blueprint = Blueprint('info', __name__, url_prefix='/info')
 info_api = Api(info_blueprint)
 
-from .auth import AuthView
+from .auth import Auth, Refresh
 
-account_api.add_resource(AuthView, '/auth')
+account_api.add_resource(Auth, '/auth')
+account_api.add_resource(Refresh, '/refresh')
 
 from .info import ApplyInfoView, BasicInfoView, PointInfoView
 

--- a/Server/app/view/account/auth.py
+++ b/Server/app/view/account/auth.py
@@ -1,11 +1,9 @@
-from datetime import timedelta
-
 from flasgger import swag_from
-from flask import request, jsonify
-from flask_jwt_extended import create_access_token, create_refresh_token
+from flask import current_app, request, jsonify
+from flask_jwt_extended import jwt_refresh_token_required
 
 from app.doc.account.auth import AUTH_POST
-from app.model import StudentModel
+from app.model import StudentModel, TokenModel
 from app.util.json_schema import json_type_validate, AUTH_POST_JSON
 from app.view.base_resource import AccountResource
 
@@ -23,3 +21,13 @@ class AuthView(AccountResource):
                 'refreshToken': refresh_token
             }
         )
+    @jwt_refresh_token_required
+    def post(self):
+        user_agent = request.headers.get('user-agent')
+        authorization = request.headers.get(current_app.config['JWT_HEADER_NAME'])
+        refresh_token = authorization[7:]
+        token = TokenModel.create_refresh_token(refresh_token, user_agent)
+
+        return jsonify(token)
+
+

--- a/Server/app/view/account/auth.py
+++ b/Server/app/view/account/auth.py
@@ -8,19 +8,19 @@ from app.util.json_schema import json_type_validate, AUTH_POST_JSON
 from app.view.base_resource import AccountResource
 
 
-class AuthView(AccountResource):
+class Auth(AccountResource):
     @json_type_validate(AUTH_POST_JSON)
     @swag_from(AUTH_POST)
     def post(self):
         student = StudentModel.login(request.json['id'], request.json['password'])
-        access_token = create_access_token(student.id, expires_delta=timedelta(hours=1))
-        refresh_token = create_refresh_token(student.id, expires_delta=timedelta(days=30))
-        return jsonify(
-            {
-                'accessToken': access_token,
-                'refreshToken': refresh_token
-            }
-        )
+        user_agent = request.headers.get('user-agent')
+        token = TokenModel.create_new_token(student.id, user_agent)
+
+        return jsonify(token)
+
+
+class Refresh(AccountResource):
+    @swag_from(REFRESH_POST)
     @jwt_refresh_token_required
     def post(self):
         user_agent = request.headers.get('user-agent')

--- a/Server/app/view/account/auth.py
+++ b/Server/app/view/account/auth.py
@@ -2,7 +2,7 @@ from flasgger import swag_from
 from flask import current_app, request, jsonify
 from flask_jwt_extended import jwt_refresh_token_required
 
-from app.doc.account.auth import AUTH_POST
+from app.doc.account.auth import AUTH_POST, REFRESH_POST
 from app.model import StudentModel, TokenModel
 from app.util.json_schema import json_type_validate, AUTH_POST_JSON
 from app.view.base_resource import AccountResource

--- a/Server/config.py
+++ b/Server/config.py
@@ -36,6 +36,7 @@ class Config:
     MAIL_PORT = 587
 
     JWT_ACCESS_TOKEN_EXPIRES = timedelta(minutes=10)
+    JWT_REFRESH_TOKEN_EXPIRES = timedelta(weeks=2)
     PROPAGATE_EXCEPTIONS = True
 
 


### PR DESCRIPTION
### TokenModel 
Refresh Token과 user-agent를 묶어 복합키로 관리.

**기존 Auth와 달라진 점**
기존은 id, pw 검증 후, 바로 token을 발급했는데, 
TokenModel을 만들어, user-agent 당 refresh_token 만 관리하기로 결정했다.
왜 access token은 관리 하지 않는가? 라는 질문에는, 
expire date가 10분도 채 되지 않는 값을 가지고 있는 것이 자원 낭비라고 생각 되어서 제외했다.

refresh token가 탈취되면 access token을 얼마든지 재생성할 수 있기 때문에 
Refresh Token을 관리함으로써, 한 개의 refresh token 만 존재하게 유지하고,
refresh token의 유효기간이 남았더라도 db에 저장된 토큰과 일치하는 토큰만 사용이 가능하게 구현하였다.